### PR TITLE
Split the filters into individual JS files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+- '6'
+sudo: false
+cache:
+  directories:
+  - node_modules
+notifications:
+  email: false

--- a/lib/bustcache.js
+++ b/lib/bustcache.js
@@ -1,0 +1,9 @@
+/* Simple Cache buster
+ * @example
+ * {{/path/to/image.jpg|bustcache}}
+ */
+function bustcache(input){
+  return input + "?" + Date.now();
+}
+
+module.exports = bustcache;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,58 +1,13 @@
 'use strict';
 
-var _str = require("underscore.string"),
-    debug = require("debug");
-
-
+/**
+ * Adds all the filters to the given Twig intstance.
+ */
 module.exports = function( twigInstance ) {
-
   return twigInstance.extend( function(){
-
-    /* Slugifies the input using underscore.string
-     * @example
-     * {{varName|slug}}
-     */
-    twigInstance.extendFilter('slug', function(input) {
-      return _str.slugify(input).toLowerCase();
-    });
-
-
-    /* When slugified and lowercased does input match the slugified and lowercased compareTo?
-     * @example
-     * {% set navItemIsActivePage = navItem.name|isSlugMatch(title) %}
-     * {% if navItemIsActivePage == true %}
-     *  <li class="active">…</li>
-     * {% else %}
-     *  <li>…</li>
-     */
-    twigInstance.extendFilter('isSlugMatch', function(input,compareTo) {
-      return _str.slugify(input).toLowerCase() == _str.slugify(compareTo).toLowerCase();
-    });
-
-
-    /* Take the input and provides a truncated version cutting off at the last full word, and appending an ellipsis…
-     * @example
-     * {{varName|limit}} or {{varName|limit(120)}}
-     */
-    twigInstance.extendFilter('limit', function(input,limit) {
-      var output,
-      input = String ( input );
-      if(!limit) limit = 140;
-      if( input.length < limit ) return input;
-      if( input.lastIndexOf( ' ' ) > 0 ) {
-        output = input.substr( 0, input.lastIndexOf( ' ', limit ) ) + '…';
-      } else {
-        output = input.substr( 0, -1 ) + '…';
-      }
-      return output;
-    });
-
-    /* Simple Cache buster
-     * @example
-     * {{/path/to/image.jpg|bustcache}}
-     */
-    twigInstance.extendFilter('bustcache', function(input){
-      return input + "?" + Date.now();
-    });
+    twigInstance.extendFilter('slug', require('./slug'));
+    twigInstance.extendFilter('isSlugMatch', require('./isSlugMatch'));
+    twigInstance.extendFilter('limit', require('./limit'));
+    twigInstance.extendFilter('bustcache', require('./bustcache'));
   });
 };

--- a/lib/isSlugMatch.js
+++ b/lib/isSlugMatch.js
@@ -1,0 +1,15 @@
+var _str = require("underscore.string");
+
+/* When slugified and lowercased does input match the slugified and lowercased compareTo?
+ * @example
+ * {% set navItemIsActivePage = navItem.name|isSlugMatch(title) %}
+ * {% if navItemIsActivePage == true %}
+ *  <li class="active">…</li>
+ * {% else %}
+ *  <li>…</li>
+ */
+function isSlugMatch(input,compareTo) {
+  return _str.slugify(input).toLowerCase() == _str.slugify(compareTo).toLowerCase();
+}
+
+module.exports = isSlugMatch;

--- a/lib/limit.js
+++ b/lib/limit.js
@@ -1,0 +1,18 @@
+/* Take the input and provides a truncated version cutting off at the last full word, and appending an ellipsis…
+ * @example
+ * {{varName|limit}} or {{varName|limit(120)}}
+ */
+function limit(input, limit) {
+  var output,
+  input = String ( input );
+  if(!limit) limit = 140;
+  if( input.length < limit ) return input;
+  if( input.lastIndexOf( ' ' ) > 0 ) {
+    output = input.substr( 0, input.lastIndexOf( ' ', limit ) ) + '…';
+  } else {
+    output = input.substr( 0, -1 ) + '…';
+  }
+  return output;
+}
+
+module.exports = limit;

--- a/lib/slug.js
+++ b/lib/slug.js
@@ -1,0 +1,11 @@
+var _str = require("underscore.string");
+
+/* Slugifies the input using underscore.string
+ * @example
+ * {{varName|slug}}
+ */
+function slug(input) {
+  return _str.slugify(input).toLowerCase();
+}
+
+module.exports = slug;

--- a/package.json
+++ b/package.json
@@ -22,12 +22,11 @@
   },
   "homepage": "https://github.com/kalamuna/kalastatic-twig-filters#readme",
   "dependencies": {
-    "debug": "^2.2.0",
-    "twig": "^0.9.5",
     "underscore.string": "^3.3.4"
   },
   "devDependencies": {
-    "mocha": "^2.5.3",
+    "twig": "^0.10.0",
+    "mocha": "^3.1.2",
     "rimraf": "^2.5.3"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,11 @@
 var assert = require('assert'),
     twigFilters = require('..'),
-    twig = twigFilters.Twig.twig;
+    Twig = require('twig'),
+    twig = Twig.twig;
 
 describe('kalastatic-twig-filters', function(){
+  // Add the Twig Filters to Twig.
+  twigFilters(Twig);
 
   it('should slugify string', function(done){
 


### PR DESCRIPTION
This allows us to load them individually. Also cleans up the dependencies between each module.